### PR TITLE
Re: #6433 Adding support for Meta objects to filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+CHANGELOG
+=========
+0.1.1
+    * Changing `#amp-enabled` default value to true.
+    * Adding `Meta` object support to `AmpFilterer::canRenderHtml`. 
+
+  -- rsumilang: Apr 21, 2007
+
+0.1.0
+    * Requires `wb:flag:amp:is-enabled` flag to `true` for usage.
+    * Provides `#amp-enabled` aspect. Default value is false.
+    * Provides AmpFilterer.
+
+  -- rsumilang

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,10 @@
-CHANGELOG
-=========
-0.1.1
+#CHANGELOG
+
+## v0.1.1
     * Changing `#amp-enabled` default value to true.
     * Adding `Meta` object support to `AmpFilterer::canRenderHtml`. 
 
-  -- rsumilang: Apr 21, 2007
-
-0.1.0
+## v0.1.0
     * Requires `wb:flag:amp:is-enabled` flag to `true` for usage.
     * Provides `#amp-enabled` aspect. Default value is false.
     * Provides AmpFilterer.
-
-  -- rsumilang

--- a/aspects/wb-mixin-amp.xml
+++ b/aspects/wb-mixin-amp.xml
@@ -12,7 +12,7 @@
     <meta id="#amp-enabled">
       <title>Enable AMP (Accelerated Mobile Pages)</title>
       <validation datatype="boolean" />
-      <default>false</default>
+      <default>true</default>
     </meta>
   </meta_defs>
   <tag_defs>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
     <provider>Warner Bros, Inc.</provider>
     <description>Provides functionality for AMP (Accelerated Mobile Pages).</description>
     <priority>100</priority>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
   </info>
 
   <config>

--- a/src/AmpFilterer.php
+++ b/src/AmpFilterer.php
@@ -45,7 +45,16 @@ class AmpFilterer extends \AbstractFilterer
             return false;
         }
 
-        return (bool)$this->getParameter('enabled');
+        $param = $this->getParameter('enabled');
+
+        if ($param instanceof \Meta) {
+            /** @type $param \Meta */
+            $val = $param->getValue();
+        } else {
+            $val = $param;
+        }
+
+        return filter_var($val, FILTER_VALIDATE_BOOLEAN);
     }
 
 }

--- a/src/AmpFilterer.php
+++ b/src/AmpFilterer.php
@@ -35,7 +35,7 @@ class AmpFilterer extends \AbstractFilterer
      *
      * Requirements:
      * - The plugin must be turned on.
-     * - Node must have the #syndication-amp meta flagged true. Pass to this method via ?amp=Data:#amp-enabled
+     * - Node must have the `#amp-enabled` meta flagged true. Pass to this method via ?amp=Data:#amp-enabled or boolean.
      *
      * @return boolean
      */


### PR DESCRIPTION
Making AMP checkbox on by default.